### PR TITLE
Allow specifying explicitly tarsnap local keyfile and add dependencies installation flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,19 +30,22 @@ variable | default value | purpose
 `backup__tarsnap_apt_key` | `40B98B68F04DE775` | ID for the key used to sign the tarsnap package
 `backup__tarsnap_username` | `changeme@example.com` | Username for tarsnap.com (only required if you want to generate a new tarsnap key)
 `backup__tarsnap_password` | `encrypt me` | Password for tarsnap.com (only required if you want to generate a new tarsnap key)
+`backup__tarsnap_local_key` | `` | Path to already generated tarsnap key
 `backup__tarsnapper_config_file` | `/etc/tarsnapper.yml` | Sets the path where the tarsnapper jobs configuration will be saved on the target host
 `backup__tarsnapper_log_file` | `/var/log/tarsnapper.log` | Sets the path to where the cronjob logs will be written
+`backup__tarsnapper_enabled` | `true` | Enables tarsnapper installation
 `backup__cron_{minute,hour,dom,month,dow}` | respectively: `28`, `3`, `*`, `*`, `*` | Interval at which to run tarsnap for backups
+`backup__install_pip` | `true` | Enables python-pip installation
 
 Notes
 -----
 
-If there is no tarsnap key file found at `files/{{ ansible_hostname }}.yml`, a
+If there is no tarsnap key specified with `backup__tarsnap_local_key` , a
 new Tarsnap key will be generated using the `backup__tarsnap_username` and
 `backup__tarsnap_password` variables, and a new machine will be registered as
 `{{ ansible_host }}`.
 
-If there is a tarsnap key at `files/{{ ansible_hostname }}.yml`, then that key
+If tarsnap key is specified with `backup__tarsnap_local_key`, then that key
 will be used instead and no new key generation or machine registration will
 occur.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,4 +12,7 @@ backup__tarsnap_keyfile: /root/tarsnap.key
 backup__tarsnap_password: 'encrypt me'
 backup__tarsnap_username: 'changeme@example.com'
 backup__tarsnapper_config_file: /etc/tarsnapper.yml
+backup__tarsnap_local_key: ''
 backup__tarsnapper_log_file: /var/log/tarsnapper.log
+backup__tarsnapper_enabled: true
+backup__install_pip: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,7 @@
   package:
     name: python-pip
     state: present
+  when: backup__install_pip
 
 - name: >
       Add tarsnap apt key (if task fails, see https://www.tarsnap.com/pkg-deb.html for latest key and override `backup__tarsnap_apt_key`)
@@ -35,13 +36,7 @@
   pip:
     name: pexpect
     state: present
-
-- name: Check for supplied tarsnap key
-  delegate_to: localhost
-  stat:
-    path: "files/{{ ansible_hostname }}.key"
-  register: local_key
-  ignore_errors: true
+  when: not backup__tarsnap_local_key
 
 - name: Generate tarsnap key and register host
   expect:
@@ -55,13 +50,15 @@
     - restore tarsnap cache
   register: tarsnap_keygen
   # the tarsnap key file in the test environment isn't a valid one
-  when: not local_key.stat.exists and backup__env != 'test'
+  when: not backup__tarsnap_local_key and backup__env != 'test'
+  tags: tarsnap-key
 
 - name: Copy supplied tarsnap key
   copy:
-    src: "files/{{ ansible_hostname }}.key"
+    src: "{{ backup__tarsnap_local_key }}"
     dest: "{{ backup__tarsnap_keyfile }}"
-  when: local_key.stat.exists
+  when: backup__tarsnap_local_key
+  tags: tarsnap-key
 
 - name: Set permissions on tarsnap key
   file:
@@ -69,6 +66,7 @@
     mode: 0600
     owner: root
     group: root
+  tags: tarsnap-key
 
 - name: Rebuild tarsnap cache
   become: true
@@ -81,6 +79,7 @@
   pip:
     name: tarsnapper
     state: present
+  when: backup__tarsnapper_enabled
 
 - name: Copy tarsnapper config file
   template:
@@ -89,6 +88,7 @@
     mode: 0600
     owner: root
     group: root
+  when: backup__tarsnapper_enabled
 
 - name: Create tarsnapper log file
   copy:
@@ -98,18 +98,20 @@
     mode: 0600
     owner: root
     group: root
+  when: backup__tarsnapper_enabled
 
 - name: Get path to tarsnapper command
   command: 'which tarsnapper'
   register: tarsnapper_full_path
   changed_when: false
+  when: backup__tarsnapper_enabled
 
 - name: Install cron
   package:
     name: cron
     state: present
 
-- name: Add backup task to cron
+- name: Add tarsnapper backup task to cron
   cron:
     name: Backup to tarsnap
     job: "{{ tarsnapper_full_path.stdout }} -c {{ backup__tarsnapper_config_file }} make >> /var/log/tarsnapper.log 2>&1"
@@ -118,3 +120,4 @@
     dom: "{{ backup__cron_dom }}"
     month: "{{ backup__cron_month }}"
     dow: "{{ backup__cron_dow }}"
+  when: backup__tarsnapper_enabled


### PR DESCRIPTION
Changelog
---------

* BREAKING CHANGE: Replace checking `files/{{ ansible_hostname }}.key` with `backup__tarsnap_local_key`
  for specifying explicitly intention to use locally generate keyfile.

* Add `backup__install_pip` for ability to disable `python-pip` installation,
  because on some newer systems it will fail (e.g. Ubuntu 20.04).

* Add `backup__tarsnapper_enabled` so it is possible to disable tarsnapper
  installation and setup (e.g. if someone wants to just install and configure tarsnap).